### PR TITLE
Travel times

### DIFF
--- a/lib/future_butcher_engine/station.ex
+++ b/lib/future_butcher_engine/station.ex
@@ -8,17 +8,17 @@ defmodule FutureButcherEngine.Station do
   @stations %{
     :beverly_hills => %{
       :base_crime_rate => 1,
-      :travel_time     => 3,
+      :travel_time     => 2,
       :max_adjustment  => 0.5
       },
     :downtown => %{
       :base_crime_rate => 2,
-      :travel_time     => 2,
+      :travel_time     => 1,
       :max_adjustment  => 0.63
       },
     :venice_beach => %{
       :base_crime_rate => 3,
-      :travel_time     => 2,
+      :travel_time     => 1,
       :max_adjustment  => 0.75
       },
     :hollywood => %{
@@ -99,7 +99,7 @@ defmodule FutureButcherEngine.Station do
 
   def random_encounter(_pack_space, _turns_left, :bell_gardens), do: {:ok, :end_transit}
 
-  def random_encounter(_pack_space, turns_left, _station) when turns_left > 22 do
+  def random_encounter(_pack_space, turns_left, _station) when turns_left > 20 do
     {:ok, :end_transit}
   end
 
@@ -129,7 +129,7 @@ defmodule FutureButcherEngine.Station do
   # Store ----------------------------------------------------------------------
 
   def generate_store(turns_left) when turns_left > @store_open_time, do: %{}
-  def generate_store(turns_left) when turns_left > @store_close_time, do: %{}
+  def generate_store(turns_left) when turns_left < @store_close_time, do: %{}
 
   def generate_store(turns_left) do
     Enum.concat(generate_weapons_stock(turns_left), generate_packs_stock(turns_left))
@@ -180,7 +180,9 @@ defmodule FutureButcherEngine.Station do
   defp get_min(:beverly_hills), do: 0
 
   defp get_max(cut, station) do
-    round(Cut.maximum_quantity(cut) * get_max_adjustment(station))
+    Cut.maximum_quantity(cut)
+    |> Kernel.*(get_max_adjustment(station))
+    |> round()
   end
 
   defp get_price(quantity, cut) do

--- a/lib/future_butcher_engine/station.ex
+++ b/lib/future_butcher_engine/station.ex
@@ -38,10 +38,17 @@ defmodule FutureButcherEngine.Station do
 
   @station_names [:beverly_hills, :downtown, :venice_beach, :hollywood, :compton, :bell_gardens]
 
+  @clinic_cost 50_000
+
+  @store_open_time 20
+  @store_close_time 5
+
   def station_names, do: @station_names
 
-  @clinic_cost 50_000
   def get_clinic_cost, do: @clinic_cost
+
+  def store_open, do: @store_open_time
+  def store_close, do: @store_close_time
 
   def get_base_crime_rate(:bell_gardens), do: {:error, :invalid_station}
 
@@ -56,7 +63,8 @@ defmodule FutureButcherEngine.Station do
   def get_max_adjustment(:bell_gardens), do: {:error, :invalid_station}
   def get_max_adjustment(station), do: @stations[station].max_adjustment
 
-  def new(:bell_gardens, turns_left) when turns_left > 20, do: {:error, :store_not_open}
+  def new(:bell_gardens, turns_left) when turns_left > @store_open_time, do: {:error, :store_not_open}
+  def new(:bell_gardnes, turns_left) when turns_left < @store_close_time, do: {:error, :store_not_open}
   def new(:bell_gardens, turns_left) do
     %Station{
       station_name: :bell_gardens,
@@ -120,7 +128,8 @@ defmodule FutureButcherEngine.Station do
 
   # Store ----------------------------------------------------------------------
 
-  def generate_store(turns_left) when turns_left > 20, do: %{}
+  def generate_store(turns_left) when turns_left > @store_open_time, do: %{}
+  def generate_store(turns_left) when turns_left > @store_close_time, do: %{}
 
   def generate_store(turns_left) do
     Enum.concat(generate_weapons_stock(turns_left), generate_packs_stock(turns_left))
@@ -131,8 +140,7 @@ defmodule FutureButcherEngine.Station do
     Weapon.weapon_types
     |> Enum.map(fn weapon -> {weapon, %{
         price: Weapon.generate_price(weapon, turns_left),
-        damage: Weapon.get_damage(weapon),
-        can_harvest: Weapon.can_harvest(weapon)
+        damage: Weapon.get_damage(weapon)
         }} end)
   end
 

--- a/lib/future_butcher_engine/weapon.ex
+++ b/lib/future_butcher_engine/weapon.ex
@@ -1,33 +1,37 @@
 defmodule FutureButcherEngine.Weapon do
+  alias FutureButcherEngine.Station
 
   @weapons %{
-    :hockey_stick => %{:damage => 10, :can_harvest => false},
-    :machete => %{:damage => 7, :can_harvest => true},
-    :hedge_clippers => %{:damage => 6, :can_harvest => true},
-    :box_cutter => %{:damage => 5, :can_harvest => true},
-    :brass_knuckles => %{:damage => 5, :can_harvest => false},
+    :katana => %{:damage => 10, :min => 100_000, :max => 800_000},
+    :machete => %{:damage => 9, :min => 60_000, :max => 480_000},
+    :power_claw => %{:damage => 8, :min => 30_000, :max => 240_000},
+    :hedge_clippers => %{:damage => 7, :min => 20_000, :max => 160_000},
+    :box_cutter => %{:damage => 6, :min => 15_000, :max => 120_000},
   }
 
   @weapons_list Map.keys(@weapons)
 
   def weapon_types, do: @weapons_list
 
-  def generate_price(weapon, turns_left) when weapon in @weapons_list do
-    harvest_offset = if can_harvest(weapon), do: 1.2, else: 1
-    damage_discount = 10 - get_damage(weapon) |> Kernel.*(16_000)
-    (100_000 - damage_discount)
-    |> Kernel./(turns_left + 1)
-    |> Kernel.*(22 * harvest_offset )
-    |> round()
-  end
+  def generate_price(_, turns_left)
+    when turns_left > 20, do: nil
+
+  def generate_price(_, turns_left)
+    when turns_left < 5, do: nil
+
+  def generate_price(weapon, turns_left)
+    when weapon in @weapons_list do
+      time = Station.store_close() - Station.store_open()
+      min = get_in(@weapons, [weapon, :min])
+      max = get_in(@weapons, [weapon, :max])
+      slope = (max - min) / time
+      intercept = max - (slope * Station.store_close())
+
+      (slope * turns_left + intercept) |> round()
+    end
 
   def generate_price(_weapon, _turns_left), do: {:error, :invalid_weapon_type}
 
   def get_damage(weapon) when weapon in @weapons_list, do: Map.get(@weapons, weapon).damage
   def get_damage(_weapon), do: {:error, :invalid_weapon_type}
-
-  def can_harvest(weapon) when weapon in @weapons_list do
-    Map.get(@weapons, weapon).can_harvest
-  end
-  def can_harvest(_), do: {:error, :invalid_weapon_type}
 end

--- a/test/game_test.exs
+++ b/test/game_test.exs
@@ -31,7 +31,7 @@ defmodule GameTest do
   describe ".start_game" do
     setup [:setup_game]
 
-    test "Sets station to downtown", context do
+    test "Sets station to compton", context do
       assert context.state.station.station_name == :compton
       assert context.state.station.market       != nil
     end
@@ -94,7 +94,7 @@ defmodule GameTest do
     setup [:setup_game, :navigate_to_beverly_hills]
 
     test "should decrement turns left", context do
-      assert context.test_state.rules.turns_left < context.state.rules.turns_left
+      assert context.state.rules.turns_left - context.test_state.rules.turns_left === 2
     end
   end
 
@@ -210,7 +210,7 @@ defmodule GameTest do
     end
 
     defp reduce_turns(context) do
-      rules = %Rules{context.state.rules | turns_left: 2}
+      rules = %Rules{context.state.rules | turns_left: 1}
       state = :sys.replace_state(context.game, fn _state -> %{context.state | rules: rules} end)
       %{game: context.game, test_state: state}
     end

--- a/test/weapon_test.exs
+++ b/test/weapon_test.exs
@@ -1,0 +1,72 @@
+defmodule WeaponTest do
+  use ExUnit.Case
+  alias FutureButcherEngine.{Station, Weapon}
+
+  describe ".generate_price" do
+    test "on turns prior to 9am" do
+      for t <- (24..21) do
+        assert nil === Weapon.generate_price(:machete, t)
+      end
+    end
+
+    test "katana on first available turn" do
+      assert 100_000 === Weapon.generate_price(
+        :katana, Station.store_open()
+      )
+    end
+
+    test "katana on last available turn" do
+      assert 800_000 === Weapon.generate_price(
+        :katana, Station.store_close()
+      )
+    end
+
+    test "machete on first available turn" do
+      assert 60_000 === Weapon.generate_price(
+        :machete, Station.store_open()
+      )
+    end
+
+    test "machete on last available turn" do
+      assert 480_000 === Weapon.generate_price(
+        :machete, Station.store_close()
+      )
+    end
+
+    test "power_claw on first available turn" do
+      assert 30_000 === Weapon.generate_price(
+        :power_claw, Station.store_open()
+      )
+    end
+
+    test "power_claw on last available turn" do
+      assert 240_000 === Weapon.generate_price(
+        :power_claw, Station.store_close()
+      )
+    end
+
+    test "hedge_clippers on first available turn" do
+      assert 20_000 === Weapon.generate_price(
+        :hedge_clippers, Station.store_open()
+      )
+    end
+
+    test "hedge_clippers on last available turn" do
+      assert 160_000 === Weapon.generate_price(
+        :hedge_clippers, Station.store_close()
+      )
+    end
+
+    test "box_cutter on first available turn" do
+      assert 15_000 === Weapon.generate_price(
+        :box_cutter, Station.store_open()
+      )
+    end
+
+    test "box_cutter on last available turn" do
+      assert 120_000 === Weapon.generate_price(
+        :box_cutter, Station.store_close()
+      )
+    end
+  end
+end


### PR DESCRIPTION
This PR reduces travel times to make the game longer.

### Changes
- Beverly Hills and Bell Garden travel times are 2 hours
- All other stations are 1 hour
- Sets Bell Gardens closing time to midnight