### PR TITLE
Reduce travel times

### DIFF
--- a/lib/future_butcher_engine/station.ex
+++ b/lib/future_butcher_engine/station.ex
@@ -8,17 +8,17 @@ defmodule FutureButcherEngine.Station do
   @stations %{
     :beverly_hills => %{
       :base_crime_rate => 1,
-      :travel_time     => 3,
+      :travel_time     => 2,
       :max_adjustment  => 0.5
       },
     :downtown => %{
       :base_crime_rate => 2,
-      :travel_time     => 2,
+      :travel_time     => 1,
       :max_adjustment  => 0.63
       },
     :venice_beach => %{
       :base_crime_rate => 3,
-      :travel_time     => 2,
+      :travel_time     => 1,
       :max_adjustment  => 0.75
       },
     :hollywood => %{
@@ -99,7 +99,7 @@ defmodule FutureButcherEngine.Station do
 
   def random_encounter(_pack_space, _turns_left, :bell_gardens), do: {:ok, :end_transit}
 
-  def random_encounter(_pack_space, turns_left, _station) when turns_left > 22 do
+  def random_encounter(_pack_space, turns_left, _station) when turns_left > 20 do
     {:ok, :end_transit}
   end
 
@@ -129,7 +129,7 @@ defmodule FutureButcherEngine.Station do
   # Store ----------------------------------------------------------------------
 
   def generate_store(turns_left) when turns_left > @store_open_time, do: %{}
-  def generate_store(turns_left) when turns_left > @store_close_time, do: %{}
+  def generate_store(turns_left) when turns_left < @store_close_time, do: %{}
 
   def generate_store(turns_left) do
     Enum.concat(generate_weapons_stock(turns_left), generate_packs_stock(turns_left))
@@ -180,7 +180,9 @@ defmodule FutureButcherEngine.Station do
   defp get_min(:beverly_hills), do: 0
 
   defp get_max(cut, station) do
-    round(Cut.maximum_quantity(cut) * get_max_adjustment(station))
+    Cut.maximum_quantity(cut)
+    |> Kernel.*(get_max_adjustment(station))
+    |> round()
   end
 
   defp get_price(quantity, cut) do

--- a/test/game_test.exs
+++ b/test/game_test.exs
@@ -31,7 +31,7 @@ defmodule GameTest do
   describe ".start_game" do
     setup [:setup_game]
 
-    test "Sets station to downtown", context do
+    test "Sets station to compton", context do
       assert context.state.station.station_name == :compton
       assert context.state.station.market       != nil
     end
@@ -94,7 +94,7 @@ defmodule GameTest do
     setup [:setup_game, :navigate_to_beverly_hills]
 
     test "should decrement turns left", context do
-      assert context.test_state.rules.turns_left < context.state.rules.turns_left
+      assert context.state.rules.turns_left - context.test_state.rules.turns_left === 2
     end
   end
 
@@ -210,7 +210,7 @@ defmodule GameTest do
     end
 
     defp reduce_turns(context) do
-      rules = %Rules{context.state.rules | turns_left: 2}
+      rules = %Rules{context.state.rules | turns_left: 1}
       state = :sys.replace_state(context.game, fn _state -> %{context.state | rules: rules} end)
       %{game: context.game, test_state: state}
     end


### PR DESCRIPTION
This PR reduces travel times to make the game longer.

###Changes
- Beverly Hills and Bell Garden travel times are 2 hours
- All other stations are 1 hour
- Fixes store closing check error